### PR TITLE
 Fix: adjust sidebar rounded corners for mobile and tablet views

### DIFF
--- a/src/game_frontend/src/components/ui/Sidebar/Tab/index.css
+++ b/src/game_frontend/src/components/ui/Sidebar/Tab/index.css
@@ -1,5 +1,5 @@
 .sidebar-tab-container{
-    @apply flex flex-col justify-center items-center py-4 px-2 min-w-[80px];
+    @apply flex flex-col justify-center items-center py-4 md:px-2 min-w-[17vw] md:min-w-[80px];
 }
 .sidebar-title{
     @apply font-sf-pro-display text-xs;

--- a/src/game_frontend/src/components/ui/Sidebar/index.css
+++ b/src/game_frontend/src/components/ui/Sidebar/index.css
@@ -14,6 +14,6 @@
         @apply fixed w-full min-h-0 h-auto bottom-0 top-auto left-0 flex flex-row justify-evenly z-50;
     }
     .sidebar-children {
-        @apply w-full min-h-[80px] flex-row bg-[#343434] justify-center items-center rounded-t-2xl  ml-0;
+        @apply w-full min-h-[80px] flex-row bg-[#343434] justify-center items-center rounded-t-2xl md:rounded-t-3xl  ml-0;
     }
 }

--- a/src/game_frontend/src/components/ui/Sidebar/index.css
+++ b/src/game_frontend/src/components/ui/Sidebar/index.css
@@ -14,6 +14,6 @@
         @apply fixed w-full min-h-0 h-auto bottom-0 top-auto left-0 flex flex-row justify-evenly z-50;
     }
     .sidebar-children {
-        @apply w-full min-h-[80px] flex-row bg-[#343434] justify-center items-center rounded-none ml-0;
+        @apply w-full min-h-[80px] flex-row bg-[#343434] justify-center items-center rounded-t-2xl  ml-0;
     }
 }


### PR DESCRIPTION
## Description
Adjust sidebar rounded corners for mobile and tablet views

- What does this PR do?
- Why is it needed?

## Screenshots
<img width="1434" alt="Screenshot 2024-12-10 at 12 54 11 PM" src="https://github.com/user-attachments/assets/31c39745-6c76-4c7e-93a9-7d751357f6ad">


### Desktop:
[Add screenshot here]

### Mobile:
[Add screenshot here]

## Approach
Briefly explain the approach taken to implement the changes. 

- How did you solve the problem?
- Any particular design patterns or optimizations?

## Issue Number (if any)
Link to the issue this PR addresses, if applicable:

Fixes #[issue_number]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked my code and corrected any misspellings
