### PR TITLE
Fix : onKeyDown Escape Button

### DIFF
--- a/src/game_frontend/src/components/ui/Modal/index.tsx
+++ b/src/game_frontend/src/components/ui/Modal/index.tsx
@@ -22,16 +22,27 @@ export default function Modal ({children, onClose, size='medium', style={}, ...p
   const dialogRef = useRef<HTMLDialogElement>(null)
 
   useEffect(()=>{
-    if(dialogRef.current){
-      dialogRef.current.showModal()
-    }
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
 
+    if(dialogRef.current){
+      dialogRef.current.showModal();
+      document.addEventListener('keydown', handleKeyDown);
+    }
+    // Cleanup function to remove the event listener and close the dialog
     return () => {
       if(dialogRef.current){
-        dialogRef.current.close()
+        dialogRef.current.close();
       }
+      // Cleanup the event listener 
+      document.removeEventListener('keydown', handleKeyDown);
     }
-  },[])
+  },[onclose])
+
+
 
   const handleOutsideClick = useCallback((e : React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     if(dialogRef.current && !dialogRef.current.contains(e.target as Node)){


### PR DESCRIPTION
## Description
This fix ensures that the modal functions correctly after pressing ```Esc``` and can be reopened without issues.

- What does this PR do?
- Why is it needed?

## Screenshots
![ScreenRecording2024-12-11at5 05 07PM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/7c1bec07-ec1f-40a5-9265-510570d03e23)

### Desktop:
[Add screenshot here]

### Mobile:
[Add screenshot here]

## Approach
 #### keyboard event , Cleanup function
- How did you solve the problem?
- Any particular design patterns or optimizations?

## Issue Number (if any)
Link to the issue this PR addresses, if applicable:

Fixes #[issue_number]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked my code and corrected any misspellings
